### PR TITLE
set default field of view to produce consistent image comparison

### DIFF
--- a/Lela/Lela.mm
+++ b/Lela/Lela.mm
@@ -120,6 +120,7 @@
     args.ImgA = RGBAImage::ReadFromUIImage(expected);
     args.ImgB = RGBAImage::ReadFromUIImage(actual);
     args.ImgDiff = new RGBAImage(args.ImgA->Get_Width(), args.ImgA->Get_Height(), "Output");
+    args.FieldOfView = 0.0;
     
     BOOL success = Yee_Compare(args);
     


### PR DESCRIPTION
otherwise we get tests to break with no image change, just because image compare uses random field of view value
