### PR TITLE
Revert "set default field of view to produce consistent image comparison...

### DIFF
--- a/Lela/Lela.mm
+++ b/Lela/Lela.mm
@@ -120,7 +120,6 @@
     args.ImgA = RGBAImage::ReadFromUIImage(expected);
     args.ImgB = RGBAImage::ReadFromUIImage(actual);
     args.ImgDiff = new RGBAImage(args.ImgA->Get_Width(), args.ImgA->Get_Height(), "Output");
-    args.FieldOfView = 0.0;
     
     BOOL success = Yee_Compare(args);
     


### PR DESCRIPTION
..."

as it does not solve the issue of comparing images with transparency
but introduces issue with regular image compare.
Correct solution would be to parse options and set the args.

This reverts commit 6214da32d13c5aebb471b280021a5cbc960c0eef.
