### PR TITLE
BUG: reference images not found on iOS 8 -fixes #9

### DIFF
--- a/Lela/Lela.mm
+++ b/Lela/Lela.mm
@@ -28,7 +28,7 @@
     }
     NSString *version = [[UIDevice currentDevice] systemVersion];
     
-    return [NSString stringWithFormat:@"%@-%dx%d@%dx~%@,iOS%@", screenName, (int)screenSize.width, (int)screenSize.height, (int)roundf(scale), idiom, version];
+    return [NSString stringWithFormat:@"%@-%dx%d@%dx-%@,iOS%@", screenName, (int)screenSize.width, (int)screenSize.height, (int)roundf(scale), idiom, version];
 }
 
 + (NSString *)directoryForTestRunNamed:(NSString *)name


### PR DESCRIPTION
The tilde in the filename seems to have caused the UIImage imageWithContentsOfFile: to return nil even if the image was present under iOS 8. There may be other solutions that don't require changing existing reference image file names, but this is the quickest path to working code I could find.