### PR TITLE
Add pixel threshold pixel option to screenshot matching

### DIFF
--- a/Lela/KIFUITestActor+Lela.h
+++ b/Lela/KIFUITestActor+Lela.h
@@ -8,8 +8,11 @@
 
 #import <KIFUITestActor.h>
 
+extern NSString * const LECompareOptionThresholdPixels;
+
 @interface KIFUITestActor (Lela)
 
 - (void)expectScreenToMatchImageNamed:(NSString *)name;
 - (void)expectScreenToMatchImageNamed:(NSString *)name options:(NSDictionary *)options;
+
 @end

--- a/Lela/KIFUITestActor+Lela.m
+++ b/Lela/KIFUITestActor+Lela.m
@@ -11,6 +11,8 @@
 #import "Lela.h"
 #import <XCTest/XCTest.h>
 
+NSString * const LECompareOptionThresholdPixels = @"LECompareOptionThresholdPixels";
+
 @implementation KIFUITestActor (Lela)
 
 + (NSString *)lelaTestRunName

--- a/Lela/Lela.mm
+++ b/Lela/Lela.mm
@@ -143,6 +143,7 @@
     args.ImgA = RGBAImage::ReadFromUIImage(expected);
     args.ImgB = RGBAImage::ReadFromUIImage(actual);
     args.ImgDiff = new RGBAImage(args.ImgA->Get_Width(), args.ImgA->Get_Height(), "Output");
+    args.ThresholdPixels = [options[LECompareOptionThresholdPixels] unsignedIntValue];
     
     BOOL success = Yee_Compare(args);
     

--- a/README.md
+++ b/README.md
@@ -74,3 +74,19 @@ This example assumes you are already familiar with KIF and borrows from the exam
     ```
 
 You will likely want to add some `waitForTimeInterval:` steps if your views take a moment to stablize.
+
+Advanced Usage - Handling Image Blur Variability 
+-------
+
+In some cases there will be minor runtime variability in how some views / images are rendered within your app. 
+This is most noticable when dealing with blurred images. 
+
+To handle this you can specify that Lela should consider the view to match the expected image if no more than X pixels differ.
+
+You can specify this threshold as follows: 
+
+```objc
+        // Test that the login screen looks correct within a threshold
+        NSUInteger numberOfPixelsThatCanDiffer = 100;
+        [tester expectScreenToMatchImageNamed:@"Filled Out Login Screen" options:@{LECompareOptionThresholdPixels : @(numberOfPixelsThatCanDiffer) }];
+```


### PR DESCRIPTION
Support for setting a threshold for screenshot matching (to handle variance in blur images) as per request in https://github.com/kif-framework/Lela/issues/12

This fix is cherry-picked from https://github.com/songsterr/Lela/commit/10485a9c9636421c06028bc950a614da1d3d1546 and originally by @Oleg-Ivanov